### PR TITLE
Make thumbnail a link

### DIFF
--- a/posts-for-page.php
+++ b/posts-for-page.php
@@ -204,7 +204,7 @@ function sc_posts_for_page($atts, $content = null){
 			{
 				if($_opts['hide_images'] != 'true')
 				{
-					$output .= $imageSrc;
+					$output .= "<a href='$link' class='thumb'>" . $imageSrc . "</a>";
 				}
 				$output .= $content;
                 if( ($_opts['hide_read_more'] != 'true'))


### PR DESCRIPTION
Mobile users tries to click image to enlarge it. It's better to let them to go to full version of post where full version of image is also located.
